### PR TITLE
Updated URLs for FAST (their own repo) and VLA (tempo)

### DIFF
--- a/pulsar_clock_corrections.py
+++ b/pulsar_clock_corrections.py
@@ -372,7 +372,6 @@ class ClockFileConverterUpdater(ClockFileUpdater):
         hdrline="",
         description="",
     ):
-
         super().__init__(
             short_description,
             filename,
@@ -456,7 +455,6 @@ class ClockFileCallableUpdater(ClockFileUpdater):
         format="tempo2",
         description="",
     ):
-
         super().__init__(
             short_description,
             filename,
@@ -495,7 +493,6 @@ class CallableUpdater(FileUpdater):
         update_interval_days=0,
         description="",
     ):
-
         super().__init__(
             short_description,
             filename,
@@ -1118,16 +1115,14 @@ updaters.append(
     ClockFileUpdater(
         "VLA",
         "tempo/clock/time_vla.dat",
-        download_url="https://raw.githubusercontent.com/"
-        "nanograv/PINT/master/src/pint/data/runtime/time_vla.dat",
+        download_url=tempo_repository_url.format("time_vla.dat"),
         authority="temporary",
         format="tempo",
         obscode="6",
         description="""Very Large Array clock corrections
 
-            This file is pulled from the PINT repository and may not be fully
-            up-to-date. (I think PINT has a more recent version than TEMPO or
-            TEMPO2.)
+            This file is pulled from the TEMPO repository and may not be fully
+            up-to-date. 
         """,
     )
 )
@@ -1163,23 +1158,13 @@ updaters.append(
     ClockFileUpdater(
         "FAST",
         "tempo/clock/time_fast.dat",
-        download_url="https://raw.githubusercontent.com/"
-        "nanograv/PINT/master/src/pint/data/runtime/time_fast.dat",
+        download_url="https://raw.githubusercontent.com/NAOC-pulsar/FAST_ClockFile/master/time_fast.dat",
         authority="temporary",
         format="tempo",
         obscode="k",
         description="""FAST clock correction file
 
-            This file is pulled from the PINT repository and may not be fully
-            up-to-date. (TEMPO doesn't seem to have this file at all.)
-
-            The original file is currently hand-generated upon request, but it is
-            planned to make the process automatic and the file downloadable (at
-            which point we will make it update automatically here).
-
-            If you have any questions about these clock corrections, the person
-            to contact is 缪晨晨 <miaocc@bao.ac.cn>, Chenchen Miao.
-
+            This file is pulled from the FAST_ClockFile repository.
         """,
     )
 )


### PR DESCRIPTION
* FAST previously pointed to PINT.  That is no longer valid.  Now it looks at https://github.com/NAOC-pulsar/FAST_ClockFile but it would be good to confirm if that is OK.
* VLA (tempo) previously pointed to PINT.  That is no longer valid.  Now it looks at tempo.  @demorest confirms that this is the best option for now but that it needs to be periodically updated manually.