### PR TITLE
Pull PKS file from Parkes repository (updated monthly) rather than TEMPO2

### DIFF
--- a/pks.py
+++ b/pks.py
@@ -5,14 +5,14 @@ from datetime import datetime, timedelta
 import pint.observatory.clock_file
 
 
-clockfilebaseurl = "https://www.parkes.atnf.csiro.au/observing/clockfiles/"
+clockfilebaseurl = "https://www.parkes.atnf.csiro.au/observing/clockfilesAA/"
 
 
 def get_mostrecent_pks_url():
     startdate = datetime(Time.now().datetime.year, Time.now().datetime.month, 1)
     currdate = startdate
     success = False
-    while currdate > datetime(2020, 1, 1):
+    while currdate > datetime(2023, 1, 1):
         try:
             filename = f"pks2gps.clk.{currdate.strftime('%Y%m%d')}"
             url = f"{clockfilebaseurl}{filename}"

--- a/pks.py
+++ b/pks.py
@@ -1,0 +1,22 @@
+from astropy.time import Time
+import astropy.utils.data
+from datetime import datetime, timedelta
+
+import pint.observatory.clock_file
+
+
+clockfilebaseurl = "https://www.parkes.atnf.csiro.au/observing/clockfiles/"
+
+
+def get_mostrecent_pks_url():
+    startdate = datetime(Time.now().datetime.year, Time.now().datetime.month, 1)
+    currdate = startdate
+    while True:
+        try:
+            filename = f"pks2gps.clk.{currdate.strftime('%Y%m%d')}"
+            url = f"{clockfilebaseurl}{filename}"
+            f = astropy.utils.data.download_file(url, cache=True)
+            break
+        except IOError:
+            currdate = (currdate + timedelta(days=-1)).replace(day=1)
+    return url

--- a/pks.py
+++ b/pks.py
@@ -11,12 +11,15 @@ clockfilebaseurl = "https://www.parkes.atnf.csiro.au/observing/clockfiles/"
 def get_mostrecent_pks_url():
     startdate = datetime(Time.now().datetime.year, Time.now().datetime.month, 1)
     currdate = startdate
-    while True:
+    success = False
+    while currdate > datetime(2020, 1, 1):
         try:
             filename = f"pks2gps.clk.{currdate.strftime('%Y%m%d')}"
             url = f"{clockfilebaseurl}{filename}"
             f = astropy.utils.data.download_file(url, cache=True)
+            success = True
             break
         except IOError:
             currdate = (currdate + timedelta(days=-1)).replace(day=1)
-    return url
+
+    return url if success else None

--- a/pks.py
+++ b/pks.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 import pint.observatory.clock_file
 
 
-clockfilebaseurl = "https://www.parkes.atnf.csiro.au/observing/clockfilesAA/"
+clockfilebaseurl = "https://www.parkes.atnf.csiro.au/observing/clockfiles/"
 
 
 def get_mostrecent_pks_url():

--- a/pulsar_clock_corrections.py
+++ b/pulsar_clock_corrections.py
@@ -1222,9 +1222,9 @@ updaters.append(
         format="tempo2",
         description="""Parkes observatory clock corrections
 
-            This file is pulled from the TEMPO2 repository and may not be fully
-            up-to-date.
-
+            This file is pulled from the Parkes observatory repository and should 
+            be up-to-date.
+            
             The comments read:
 
                 Tie of Parkes clock to GPS time standard. Sources are listed below.

--- a/pulsar_clock_corrections.py
+++ b/pulsar_clock_corrections.py
@@ -15,6 +15,7 @@ from pint.observatory.clock_file import ClockFile
 
 import bipm
 import iers
+import pks
 
 public_repo_url_raw = (
     "https://raw.githubusercontent.com/ipta/pulsar-clock-corrections/main/"
@@ -372,7 +373,6 @@ class ClockFileConverterUpdater(ClockFileUpdater):
         hdrline="",
         description="",
     ):
-
         super().__init__(
             short_description,
             filename,
@@ -456,7 +456,6 @@ class ClockFileCallableUpdater(ClockFileUpdater):
         format="tempo2",
         description="",
     ):
-
         super().__init__(
             short_description,
             filename,
@@ -495,7 +494,6 @@ class CallableUpdater(FileUpdater):
         update_interval_days=0,
         description="",
     ):
-
         super().__init__(
             short_description,
             filename,
@@ -1219,7 +1217,7 @@ updaters.append(
     ClockFileUpdater(
         "Parkes",
         "T2runtime/clock/pks2gps.clk",
-        download_url=tempo2_repository_url.format("pks2gps.clk"),
+        download_url=pks.get_mostrecent_pks_url(),
         authority="temporary",
         format="tempo2",
         description="""Parkes observatory clock corrections

--- a/pulsar_clock_corrections.py
+++ b/pulsar_clock_corrections.py
@@ -1213,11 +1213,14 @@ updaters.append(
         """,
     )
 )
+pks_url = pks.get_mostrecent_pks_url()
+if pks_url is None:
+    pks_url = tempo2_repository_url.format("pks2gps.clk")
 updaters.append(
     ClockFileUpdater(
         "Parkes",
         "T2runtime/clock/pks2gps.clk",
-        download_url=pks.get_mostrecent_pks_url(),
+        download_url=pks_url,
         authority="temporary",
         format="tempo2",
         description="""Parkes observatory clock corrections


### PR DESCRIPTION
https://www.parkes.atnf.csiro.au/observing/Calibration_and_Data_Processing_Files.html has monthly files for the TEMPO2 clock corrections.  Rather than just look at the TEMPO2 repository (old) it queries for the most recent file on that page and returns the appropriate URL.

If it cannot find a URL of a recent file it will fall-back to the TEMPO2 version.