### PR TITLE
Hot Fix to the CI & Updater

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Check updates work
+name: Check that Updates are Working
 on: 
   push:
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,24 @@ jobs:
     run-update-script-but-dont-commit:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
-            - run: pip install -r requirements.txt
-            - run: git clone https://github.com/ipta/pulsar-clock-corrections.git  --branch gh-pages --single-branch /tmp/gh-pages --depth 1
-            - run: python update_clock_corrections.py --gh-pages /tmp/gh-pages
+            - uses: actions/checkout@v4
+            - name: Set-Up Python Env
+              uses: mamba-org/setup-micromamba@v1
+              with: init-shell: bash
+              environment-name: clocks
+              cache-environment: true
+              cache-downloads: true
+              create-args: >-
+                -c conda-forge
+                python=3.11
+                astropy
+                git
+            - name: Install Git Version of PINT
+              shell: bash -el {0}
+              run: pip install -r requirements.txt
+            - name: Clone the Directory & Switch to GH-Pages
+              shell: bash -el {0}
+              run: git clone https://github.com/ipta/pulsar-clock-corrections.git  --branch gh-pages --single-branch /tmp/gh-pages --depth 1
+            - name: Test Updating the Clocks
+              shell: bash -el {0}
+              run: python update_clock_corrections.py --gh-pages /tmp/gh-pages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,15 +9,16 @@ jobs:
             - uses: actions/checkout@v4
             - name: Set-Up Python Env
               uses: mamba-org/setup-micromamba@v1
-              with: init-shell: bash
-              environment-name: clocks
-              cache-environment: true
-              cache-downloads: true
-              create-args: >-
-                -c conda-forge
-                python=3.11
-                astropy
-                git
+              with: 
+                init-shell: bash
+                environment-name: clocks
+                cache-environment: true
+                cache-downloads: true
+                create-args: >-
+                  -c conda-forge
+                  python=3.11
+                  astropy
+                  git
             - name: Install Git Version of PINT
               shell: bash -el {0}
               run: pip install -r requirements.txt

--- a/.github/workflows/update-clock-corrections.yml
+++ b/.github/workflows/update-clock-corrections.yml
@@ -1,4 +1,4 @@
-name: update-clock-corrections
+name: Regular Update to Clock Corrections
 on: 
   schedule:
     # * is a special character in YAML so you have to quote this string
@@ -7,18 +7,40 @@ jobs:
     run-update-script:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
-            - run: pip install -r requirements.txt
-            - run: git clone https://github.com/ipta/pulsar-clock-corrections.git  --branch gh-pages --single-branch /tmp/gh-pages --depth 1
-            - run: python update_clock_corrections.py --gh-pages /tmp/gh-pages
-            - run: |
+            - uses: actions/checkout@v4
+             - name: Set-Up Python Env
+              uses: mamba-org/setup-micromamba@v1
+              with: 
+                init-shell: bash
+                environment-name: clocks
+                cache-environment: true
+                cache-downloads: true
+                create-args: >-
+                  -c conda-forge
+                  python=3.11
+                  astropy
+                  git
+            - name: Install Specified Requirements
+              shell: bash -el {0}
+              run: pip install -r requirements.txt
+            - name: Clone the Directory & Switch to GH-Pages
+              shell: bash -el {0}
+              run: git clone https://github.com/ipta/pulsar-clock-corrections.git  --branch gh-pages --single-branch /tmp/gh-pages --depth 1
+            - name: Update the Clock Files from Remote Repositories
+              shell: bash -el {0}
+              run: python update_clock_corrections.py --gh-pages /tmp/gh-pages
+            - name: Push Clock Corrections to Remote Repo
+              shell: bash -el {0}
+              run: |
                 git config --global user.name "Anne Archibald"
                 git config --global user.email 'aarchiba@users.noreply.github.com'
                 git add tempo T2runtime log
                 git commit -am "Routine repo update from Github action `date`"
                 git log -n 1
                 git push
-            - run: |
+            - name: Push all Clock Files to the GH Page
+              shell: bash -el {0}
+              run: |
                 cd /tmp/gh-pages 
                 git add .
                 git commit -am "Routine gh-pages update from Github action `date`"

--- a/.github/workflows/update-clock-corrections.yml
+++ b/.github/workflows/update-clock-corrections.yml
@@ -8,7 +8,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
-             - name: Set-Up Python Env
+            - name: Set-Up Python Env
               uses: mamba-org/setup-micromamba@v1
               with: 
                 init-shell: bash
@@ -16,10 +16,10 @@ jobs:
                 cache-environment: true
                 cache-downloads: true
                 create-args: >-
-                  -c conda-forge
-                  python=3.11
-                  astropy
-                  git
+                    -c conda-forge
+                    python=3.11
+                    astropy
+                    git
             - name: Install Specified Requirements
               shell: bash -el {0}
               run: pip install -r requirements.txt


### PR DESCRIPTION
I adjusted the CI & Updater GitHub Actions to use actions@v4 and micromamba@v1. This should match what we are doing in `pint-pal` which seems to stabilize our environment issues nicely.

~ Joe G.